### PR TITLE
[4-feat]: add second role tag with Persian quote

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -82,11 +82,18 @@ const beliefs = [
     </div>
 
     <!-- Role tag -->
-    <span
-      class="text-[11px] font-medium tracking-widest text-green bg-green-tint px-2.5 py-1 rounded-full w-fit mb-6 uppercase"
-    >
-      Backend Engineer
-    </span>
+    <div class="mb-6">
+      <span
+        class="text-[11px] font-medium tracking-widest text-green bg-green-tint mr-2 px-2.5 py-1 rounded-full w-fit mb-6 uppercase"
+      >
+        Backend Engineer
+      </span>
+      <span
+        class="text-[11px] font-medium tracking-widest text-green bg-green-tint px-2.5 py-1 rounded-full w-fit mb-6 uppercase"
+      >
+        The creator of the quote "کل المان یک برگ نمی‌ارزد"
+      </span>
+    </div>
 
     <!-- Headline -->
     <h1 class="text-[42px] font-normal leading-[1.15] text-ink mb-2">


### PR DESCRIPTION
Replace the single role span with a wrapper div containing two role tags: the original "Backend Engineer" tag (spacing adjusted via mr-2) and a new tag: The creator of the quote "کل المان یک برگ نمی‌ارزد". This change displays an additional role/quote inline beneath the hero and adjusts spacing between tags.